### PR TITLE
Fixed: AlertXController presented again after AlertX dismissed

### DIFF
--- a/Sources/AlertX/AlertX-Elements/Button.swift
+++ b/Sources/AlertX/AlertX-Elements/Button.swift
@@ -20,11 +20,6 @@ extension AlertX {
         let text: Text
         var buttonType: AlertX.ButtonType = .default
         
-        let dismissAction: () -> Void = {
-            AlertX_View.currentAlertXVCReference?.dismiss(animated: true, completion: nil)
-            AlertX_View.currentAlertXVCReference = nil
-        }
-        
         var buttonAction: (() -> Void)?
         
         private init(text: Text, buttonType: AlertX.ButtonType, action: (() -> Void)? = {}) {
@@ -34,13 +29,16 @@ extension AlertX {
         }
         
         public var body: some View {
-            
             SystemButton(action: {
                 
-                if let action = self.buttonAction {
-                    action()
-                }
-                self.dismissAction()
+                //First dismiss AlertXViewController and then perform action
+                AlertX_View.currentAlertXVCReference?.dismiss(animated: true, completion: {
+                    AlertX_View.currentAlertXVCReference = nil
+                    
+                    if let action = self.buttonAction {
+                        action()
+                    }
+                })
                 
             }, label: {
                 text
@@ -67,5 +65,3 @@ extension AlertX {
     }
     
 }
-
-

--- a/Sources/AlertX/Essentials/View+Extension.swift
+++ b/Sources/AlertX/Essentials/View+Extension.swift
@@ -12,23 +12,24 @@ extension View {
     
     public func alertX(isPresented: Binding<Bool>, content: () -> AlertX) -> some View {
         
-        let alertX_view = AlertX_View(visible: isPresented, alertX: content())
-        let alertXVC = AlertXViewController(alertX_view: alertX_view, isPresented: isPresented)
-        alertXVC.modalPresentationStyle = .overCurrentContext
-        alertXVC.view.backgroundColor = UIColor.clear
-        alertXVC.modalTransitionStyle = .crossDissolve
-                
-        if isPresented.wrappedValue {
-            if AlertX_View.currentAlertXVCReference == nil {
-                AlertX_View.currentAlertXVCReference = alertXVC
-            }
+        if isPresented.wrappedValue && AlertX_View.currentAlertXVCReference == nil {
+            
+            let alertX_view = AlertX_View(visible: isPresented, alertX: content())
+            let alertXVC = AlertXViewController(alertX_view: alertX_view, isPresented: isPresented)
+            alertXVC.modalPresentationStyle = .overCurrentContext
+            alertXVC.view.backgroundColor = UIColor.clear
+            alertXVC.modalTransitionStyle = .crossDissolve
+            
+            AlertX_View.currentAlertXVCReference = alertXVC
             
             let rootVC = UIApplication.shared.windows.first?.rootViewController
-            rootVC?.present(alertXVC, animated: true, completion: nil)
+            rootVC?.present(AlertX_View.currentAlertXVCReference!, animated: true, completion: nil)
+            
         } else {
-            alertXVC.dismiss(animated: true, completion: nil)
+            AlertX_View.currentAlertXVCReference?.dismiss(animated: true, completion: nil)
         }
         
         return self
     }
 }
+


### PR DESCRIPTION
Whenever the button performs the action which makes changes in the SwiftUI view hierarchy, the AlertXViewController is presented again resulting from a call that happened while  user's action was performed.