### PR TITLE
Add option for custom corner radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ To create a custom theme, use the following method which offers a variety of opt
                        cancelButtonColor: Color,
                        cancelButtonTextColor: Color,
                        defaultButtonColor: Color,
-                       defaultButtonTextColor: Color)
+                       defaultButtonTextColor: Color,
+                       roundedCornerRadius: CGFloat)
 
 
 ## Animations

--- a/Sources/AlertX/AlertX-Elements/AlertX.swift
+++ b/Sources/AlertX/AlertX-Elements/AlertX.swift
@@ -40,7 +40,7 @@ public struct AlertX: View {
         }
         
         self.theme = theme
-		self.alertX_cornerRadius = theme.enableRoundedCorners ? theme.roundedCornerRadius : 0.0
+        self.alertX_cornerRadius = theme.enableRoundedCorners ? theme.roundedCornerRadius : 0.0
         self.alertX_shadowRadius = theme.enableShadow ? AlertX.defaultShadowRadius : 0.0
         
         self.animation = animation

--- a/Sources/AlertX/AlertX-Elements/AlertX.swift
+++ b/Sources/AlertX/AlertX-Elements/AlertX.swift
@@ -40,7 +40,7 @@ public struct AlertX: View {
         }
         
         self.theme = theme
-        self.alertX_cornerRadius = theme.enableRoundedCorners ? AlertX.defaultCornerRadius : 0.0
+		self.alertX_cornerRadius = theme.enableRoundedCorners ? theme.roundedCornerRadius : 0.0
         self.alertX_shadowRadius = theme.enableShadow ? AlertX.defaultShadowRadius : 0.0
         
         self.animation = animation
@@ -53,7 +53,7 @@ public struct AlertX: View {
         self.buttonStack = buttonStack
         
         self.theme = theme
-        self.alertX_cornerRadius = theme.enableRoundedCorners ? AlertX.defaultCornerRadius : 0.0
+        self.alertX_cornerRadius = theme.enableRoundedCorners ? theme.roundedCornerRadius : 0.0
         self.alertX_shadowRadius = theme.enableShadow ? AlertX.defaultShadowRadius : 0.0
         
         self.animation = animation
@@ -85,7 +85,7 @@ public struct AlertX: View {
                                     self.buttonStack?[$0]
                                         .background(self.buttonStack![$0].buttonType == AlertX.ButtonType.default ? self.theme.defaultButtonColor : self.theme.cancelButtonColor)
                                     .foregroundColor(self.buttonStack![$0].buttonType == AlertX.ButtonType.default ? self.theme.defaultButtonTextColor : self.theme.cancelButtonTextColor)
-                                    .cornerRadius(self.theme.enableRoundedCorners ? AlertX.defaultCornerRadius : 0.0)
+                                    .cornerRadius(self.theme.enableRoundedCorners ? theme.roundedCornerRadius : 0.0)
                                 
                                 }
                             }.padding()
@@ -99,7 +99,7 @@ public struct AlertX: View {
                                         self.buttonStack?[$0]
                                             .background(self.buttonStack![$0].buttonType == AlertX.ButtonType.default ? self.theme.defaultButtonColor : self.theme.cancelButtonColor)
                                         .foregroundColor(self.buttonStack![$0].buttonType == AlertX.ButtonType.default ? self.theme.defaultButtonTextColor : self.theme.cancelButtonTextColor)
-                                        .cornerRadius(self.theme.enableRoundedCorners ? AlertX.defaultCornerRadius : 0.0)
+                                        .cornerRadius(self.theme.enableRoundedCorners ? theme.roundedCornerRadius : 0.0)
                                             .padding(.bottom, 10)
                                     
                                 }
@@ -110,7 +110,7 @@ public struct AlertX: View {
                         
                     }
                     
-            }.background(AlertX.Window(color: theme.windowColor, cornerRadiusEnabled: theme.enableRoundedCorners, transparencyEnabled: theme.enableTransparency))
+            }.background(AlertX.Window(color: theme.windowColor, cornerRadius: self.theme.enableRoundedCorners ? theme.roundedCornerRadius : 0.0, transparencyEnabled: theme.enableTransparency))
                 .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
                 .padding()
                 .shadow(radius: alertX_shadowRadius)

--- a/Sources/AlertX/AlertX-Elements/Window.swift
+++ b/Sources/AlertX/AlertX-Elements/Window.swift
@@ -16,10 +16,10 @@ extension AlertX {
         var windowColorOpacity: Double
         var cornerRadius: CGFloat
         
-        public init(color: Color, cornerRadiusEnabled: Bool, transparencyEnabled: Bool) {
+        public init(color: Color, cornerRadius: CGFloat, transparencyEnabled: Bool) {
             self.windowColor = color
             self.windowColorOpacity = transparencyEnabled ? AlertX.defaultAlertOpacity : 1.0
-            self.cornerRadius = cornerRadiusEnabled ? AlertX.defaultCornerRadius : 0
+            self.cornerRadius = cornerRadius
         }
         
         var body: some View {

--- a/Sources/AlertX/Options/Themes.swift
+++ b/Sources/AlertX/Options/Themes.swift
@@ -14,12 +14,14 @@ extension AlertX {
         
         //Default theme
         public static var defaultTheme: AlertX.Theme = graphite()
+		public static let defaultCornerRadius = AlertX.defaultCornerRadius
         
         // General Properties
         var windowColor: Color
         var alertTextColor: Color
         var enableShadow: Bool
         var enableRoundedCorners: Bool
+		var roundedCornerRadius: CGFloat
         var enableTransparency: Bool
         
         // Button Properties
@@ -34,12 +36,13 @@ extension AlertX {
         }
         
         // Private init
-        private init(windowColor: Color, alertTextColor: Color, enableShadow: Bool, enableRoundedCorners: Bool, enableTransparency: Bool, cancelButtonColor: Color, cancelButtonTextColor: Color, defaultButtonColor: Color, defaultButtonTextColor: Color) {
+		private init(windowColor: Color, alertTextColor: Color, enableShadow: Bool, enableRoundedCorners: Bool, enableTransparency: Bool, cancelButtonColor: Color, cancelButtonTextColor: Color, defaultButtonColor: Color, defaultButtonTextColor: Color, roundedCornerRadius: CGFloat = defaultCornerRadius) {
             
             self.windowColor = windowColor
             self.alertTextColor = alertTextColor
             self.enableShadow = enableShadow
             self.enableRoundedCorners = enableRoundedCorners
+			self.roundedCornerRadius = roundedCornerRadius
             self.enableTransparency = enableTransparency
             
             self.cancelButtonColor = cancelButtonColor
@@ -49,7 +52,7 @@ extension AlertX {
         }
         
         // Define custom theme
-        public static func custom(windowColor: Color, alertTextColor: Color, enableShadow: Bool, enableRoundedCorners: Bool, enableTransparency: Bool, cancelButtonColor: Color, cancelButtonTextColor: Color, defaultButtonColor: Color, defaultButtonTextColor: Color) -> AlertX.Theme {
+        public static func custom(windowColor: Color, alertTextColor: Color, enableShadow: Bool, enableRoundedCorners: Bool, enableTransparency: Bool, cancelButtonColor: Color, cancelButtonTextColor: Color, defaultButtonColor: Color, defaultButtonTextColor: Color, roundedCornerRadius: CGFloat = defaultCornerRadius) -> AlertX.Theme {
             
             let theme = AlertX.Theme(windowColor: windowColor,
                                      alertTextColor: alertTextColor,
@@ -59,7 +62,8 @@ extension AlertX {
                                      cancelButtonColor: cancelButtonColor,
                                      cancelButtonTextColor: cancelButtonTextColor,
                                      defaultButtonColor: defaultButtonColor,
-                                     defaultButtonTextColor: defaultButtonTextColor)
+                                     defaultButtonTextColor: defaultButtonTextColor,
+									 roundedCornerRadius: roundedCornerRadius)
             
             return theme
         }

--- a/Sources/AlertX/Options/Themes.swift
+++ b/Sources/AlertX/Options/Themes.swift
@@ -14,14 +14,14 @@ extension AlertX {
         
         //Default theme
         public static var defaultTheme: AlertX.Theme = graphite()
-		public static let defaultCornerRadius = AlertX.defaultCornerRadius
+        public static let defaultCornerRadius = AlertX.defaultCornerRadius
         
         // General Properties
         var windowColor: Color
         var alertTextColor: Color
         var enableShadow: Bool
         var enableRoundedCorners: Bool
-		var roundedCornerRadius: CGFloat
+        var roundedCornerRadius: CGFloat
         var enableTransparency: Bool
         
         // Button Properties
@@ -36,7 +36,7 @@ extension AlertX {
         }
         
         // Private init
-		private init(windowColor: Color, alertTextColor: Color, enableShadow: Bool, enableRoundedCorners: Bool, enableTransparency: Bool, cancelButtonColor: Color, cancelButtonTextColor: Color, defaultButtonColor: Color, defaultButtonTextColor: Color, roundedCornerRadius: CGFloat = defaultCornerRadius) {
+        private init(windowColor: Color, alertTextColor: Color, enableShadow: Bool, enableRoundedCorners: Bool, enableTransparency: Bool, cancelButtonColor: Color, cancelButtonTextColor: Color, defaultButtonColor: Color, defaultButtonTextColor: Color, roundedCornerRadius: CGFloat = defaultCornerRadius) {
             
             self.windowColor = windowColor
             self.alertTextColor = alertTextColor
@@ -63,7 +63,7 @@ extension AlertX {
                                      cancelButtonTextColor: cancelButtonTextColor,
                                      defaultButtonColor: defaultButtonColor,
                                      defaultButtonTextColor: defaultButtonTextColor,
-									 roundedCornerRadius: roundedCornerRadius)
+                                     roundedCornerRadius: roundedCornerRadius)
             
             return theme
         }


### PR DESCRIPTION
Adds an optional parameter to themes for a custom corner radius. If a custom value isn't specified then it will default to `AlertX.defaultCornerRadius`. This is in response to #9 