### PR TITLE
Fixed: Button action couldn't get performed if the alert isn't presented by View.alertX modifier

### DIFF
--- a/Sources/AlertX/AlertX-Elements/Button.swift
+++ b/Sources/AlertX/AlertX-Elements/Button.swift
@@ -31,21 +31,20 @@ extension AlertX {
         public var body: some View {
             SystemButton(action: {
                 
-                if let reference = AlertX_View.currentAlertXVCReference {
-                    // For alerts presented by View.alertX modifier, first dismiss AlertXViewController and then perform action
-                    AlertX_View.currentAlertXVCReference?.dismiss(animated: true, completion: {
-                        AlertX_View.currentAlertXVCReference = nil
-                        
-                        if let action = self.buttonAction {
-                            action()
-                        }
-                    })
+                func prepareForDismiss(completion: @escaping () -> Void) {
                     
-                } else {
-                    // For alerts presented by custom modifiers like View.fullScreenCover directly with AlertX view, just perform action
-                    if let action = self.buttonAction {
-                        action()
+                    if let reference = AlertX_View.currentAlertXVCReference {
+                        AlertX_View.currentAlertXVCReference = nil
+                        reference.dismiss(animated: true, completion: completion)
+                        
+                    } else {
+                        completion()
                     }
+                    
+                }
+                
+                prepareForDismiss {
+                    buttonAction?()
                 }
                 
             }, label: {

--- a/Sources/AlertX/AlertX-Elements/Button.swift
+++ b/Sources/AlertX/AlertX-Elements/Button.swift
@@ -31,14 +31,22 @@ extension AlertX {
         public var body: some View {
             SystemButton(action: {
                 
-                //First dismiss AlertXViewController and then perform action
-                AlertX_View.currentAlertXVCReference?.dismiss(animated: true, completion: {
-                    AlertX_View.currentAlertXVCReference = nil
+                if let reference = AlertX_View.currentAlertXVCReference {
+                    // For alerts presented by View.alertX modifier, first dismiss AlertXViewController and then perform action
+                    AlertX_View.currentAlertXVCReference?.dismiss(animated: true, completion: {
+                        AlertX_View.currentAlertXVCReference = nil
+                        
+                        if let action = self.buttonAction {
+                            action()
+                        }
+                    })
                     
+                } else {
+                    // For alerts presented by custom modifiers like View.fullScreenCover directly with AlertX view, just perform action
                     if let action = self.buttonAction {
                         action()
                     }
-                })
+                }
                 
             }, label: {
                 text


### PR DESCRIPTION
I'm using this library in my project, and for some reason I need to use it directly generated by the AlertX initializer over .alertX modifier.

And from v1.1.1 button actions are only performed when there is a AlertXVCReference, which is only applied inside .alertX modifier. So I fixed this problem by run button action directly if there is no AlertXVCReference found.

Alternatively, maybe we can also make the AlertX initializer internal to prevent using AlertX view directly, but that would make this library less customizable, and also, in my case, I need to make a modifier using `Binding<AlertContent?>` over `Binding<Bool>` to control the presentation of alerts.